### PR TITLE
Correct Handler types signature; Add generics

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -5,13 +5,13 @@ export = transform
 
 // transform([records], [options], handler, [callback])
 
-declare function transform(handler: transform.Handler, callback?: transform.Callback): transform.Transformer
-declare function transform(records: Array<any>, handler: transform.Handler, callback?: transform.Callback): transform.Transformer
-declare function transform(options: transform.Options, handler: transform.Handler, callback?: transform.Callback): transform.Transformer
-declare function transform(records: Array<any>, options: transform.Options, handler: transform.Handler, callback?: transform.Callback): transform.Transformer
+declare function transform<T = any, U = any>(handler: transform.Handler<T, U>, callback?: transform.Callback): transform.Transformer
+declare function transform<T = any, U = any>(records: Array<T>, handler: transform.Handler<T, U>, callback?: transform.Callback): transform.Transformer
+declare function transform<T = any, U = any>(options: transform.Options, handler: transform.Handler<T, U>, callback?: transform.Callback): transform.Transformer
+declare function transform<T = any, U = any>(records: Array<T>, options: transform.Options, handler: transform.Handler<T, U>, callback?: transform.Callback): transform.Transformer
 declare namespace transform {
-    type Handler = (record: Array<any>, callback: HandlerCallback, params?: any) => any
-    type HandlerCallback = (err?: null | Error, record?: any) => void
+    type Handler<T = any, U = any> = (record: T, callback: HandlerCallback, params?: any) => U
+    type HandlerCallback<T = any> = (err?: null | Error, record?: T) => void
     type Callback = (err?: null | Error, output?: string) => void
     interface Options {
         /**
@@ -28,9 +28,9 @@ declare namespace transform {
         params?: any
     }
     interface State {
-      finished: number
-      running: number
-      started: number
+        finished: number
+        running: number
+        started: number
     }
     class Transformer extends stream.Transform {
         constructor(options: Options)

--- a/lib/sync.d.ts
+++ b/lib/sync.d.ts
@@ -5,7 +5,7 @@ export = transform
 
 // transform(records, [options], handler)
 
-type Handler<T = any, U = any> = (record: Array<T>) => U
+type Handler<T = any, U = any> = (record: T) => U
 declare function transform<T = any, U = any>(records: Array<T>, handler: Handler<T, U>): Array<U>
 declare function transform<T = any, U = any>(records: Array<T>, options: streamTransform.Options, handler: Handler<T, U>): Array<U>
 declare namespace transform { }

--- a/lib/sync.d.ts
+++ b/lib/sync.d.ts
@@ -5,7 +5,7 @@ export = transform
 
 // transform(records, [options], handler)
 
-type Handler = (record: Array<any>) => any
-declare function transform(records: Array<any>, handler: Handler): Array<any>
-declare function transform(records: Array<any>, options: streamTransform.Options, handler: Handler): Array<any>
-declare namespace transform {}
+type Handler<T = any, U = any> = (record: Array<T>) => U
+declare function transform<T = any, U = any>(records: Array<T>, handler: Handler<T, U>): Array<U>
+declare function transform<T = any, U = any>(records: Array<T>, options: streamTransform.Options, handler: Handler<T, U>): Array<U>
+declare namespace transform { }


### PR DESCRIPTION
When updating the package recently in one of my projects, I was surprised that the typescript types didn't seem to match how the transform function behaved. Much like @dvarnai in https://github.com/adaltas/node-stream-transform/pull/27, after some tinkering I figured that the issue stemmed from the fact that the Handler was typed to always receive an array of `any` where it actually received each element of the `records`-param/stream in turn.

This PR corrects the signature of the `Handler` and `HandlerCallback` to operate on a single element of the `records`-array, or stream, per call. It also adds some generics to the signature allowing for some extra type safety through inference or manual typing. In the case no type can be inferred the generics will default to use `any` to stay true to the original signature and not requiring anyone to add types when they upgrade unless they want to.